### PR TITLE
profile 닉네임 변경시 게시글, 댓글 닉네임변경

### DIFF
--- a/src/components/profile/Profile.tsx
+++ b/src/components/profile/Profile.tsx
@@ -135,6 +135,21 @@ const Profile = () => {
         if (error) {
           throw error;
         }
+
+        // 관련 게시글의 닉네임 업데이트
+        const { error: postUpdateError } = await supabase
+          .from("posts")
+          .update({ userName: newNickName }) 
+          .eq("userId", userInfo?.id);
+        if (postUpdateError) throw postUpdateError
+
+        // 관련 댓글의 닉네임 업데이트
+        const { error: commentUpdateError } = await supabase
+          .from("comments")
+          .update({ userName: newNickName }) 
+          .eq("userId", userInfo?.id);
+        if (commentUpdateError) throw commentUpdateError;
+        
         setUserInfo((prev: any) => ({
           ...prev,
           nickname: newNickName,

--- a/src/components/profile/Profile.tsx
+++ b/src/components/profile/Profile.tsx
@@ -145,11 +145,11 @@ const Profile = () => {
 
         // 관련 댓글의 닉네임 업데이트
         const { error: commentUpdateError } = await supabase
-          .from("comments")
+          .from("postComment")
           .update({ userName: newNickName }) 
           .eq("userId", userInfo?.id);
         if (commentUpdateError) throw commentUpdateError;
-        
+
         setUserInfo((prev: any) => ({
           ...prev,
           nickname: newNickName,


### PR DESCRIPTION
```
        // 관련 게시글의 닉네임 업데이트
        const { error: postUpdateError } = await supabase
          .from("posts")
          .update({ userName: newNickName }) 
          .eq("userId", userInfo?.id);
        if (postUpdateError) throw postUpdateError

        // 관련 댓글의 닉네임 업데이트
        const { error: commentUpdateError } = await supabase
          .from("postComment")
          .update({ userName: newNickName }) 
          .eq("userId", userInfo?.id);
        if (commentUpdateError) throw commentUpdateError;
```
닉네임 변경하면 게시글, 댓글 닉네임도 변경되게 로직 추가했습니다!