### PR TITLE
[feat] community 목록 정렬

### DIFF
--- a/src/components/communityComponents/CommunityList.tsx
+++ b/src/components/communityComponents/CommunityList.tsx
@@ -15,7 +15,6 @@ const CommunityList: React.FC = () => {
 
   useEffect(() => {
     fetchCommunity();
-    console.log(userInfo);
   }, []);
 
   const [editId, setEditId] = useState<string | null>(null);
@@ -26,7 +25,12 @@ const CommunityList: React.FC = () => {
   );
 
   useEffect(() => {
-    setCommunityContent(initialCommunityContent);
+    const sortedContent = initialCommunityContent.slice().sort((a, b) => {
+      return (
+        new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+      );
+    });
+    setCommunityContent(sortedContent);
   }, [initialCommunityContent]);
 
   const handleSearch = (searchTerm: string) => {


### PR DESCRIPTION
작성한 글 수정했을 때 전체 목록 순서가 변경되는 것을 수정했습니다

```tsx
  useEffect(() => {
    const sortedContent = initialCommunityContent.slice().sort((a, b) => {
      return (
        new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
      );
    });
    setCommunityContent(sortedContent);
  }, [initialCommunityContent]);
```